### PR TITLE
增加取词菜单，使用大模型进行进行辅助、提供查词、翻译、语句分析功能。

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -6,7 +6,7 @@ import { DEFAULT_SETTINGS } from './src/settings';
 import { registerReadingModeHighlighter } from './src/ui/reading-mode-highlighter';
 import { registerPDFHighlighter, cleanupPDFHighlighter } from './src/ui/pdf-highlighter';
 import { VocabularyManager, MasteredService, createWordHighlighterExtension, highlighterManager } from './src/core';
-import { DefinitionPopover, HiWordsSettingTab, HiWordsSidebarView, SIDEBAR_VIEW_TYPE, AddWordModal } from './src/ui';
+import { DefinitionPopover, HiWordsSettingTab, HiWordsSidebarView, SIDEBAR_VIEW_TYPE, AddWordModal, SelectionBubbleMenu } from './src/ui';
 import { i18n } from './src/i18n';
 import { registerCommands } from './src/commands';
 import { registerEvents } from './src/events';
@@ -17,6 +17,7 @@ export default class HiWordsPlugin extends Plugin {
     vocabularyManager!: VocabularyManager;
     definitionPopover!: DefinitionPopover;
     masteredService!: MasteredService;
+    selectionBubbleMenu!: SelectionBubbleMenu;
     editorExtensions: Extension[] = [];
     private isSidebarInitialized = false;
 
@@ -38,6 +39,9 @@ export default class HiWordsPlugin extends Plugin {
         this.addChild(this.definitionPopover);
         this.definitionPopover.setVocabularyManager(this.vocabularyManager);
         this.definitionPopover.setMasteredService(this.masteredService);
+        
+        this.selectionBubbleMenu = new SelectionBubbleMenu(this);
+        this.addChild(this.selectionBubbleMenu);
         
         // 注册侧边栏视图
         this.registerView(
@@ -186,6 +190,9 @@ export default class HiWordsPlugin extends Plugin {
         await this.saveData(this.settings);
         this.vocabularyManager.updateSettings(this.settings);
         this.masteredService.updateSettings();
+        if (this.selectionBubbleMenu) {
+            this.selectionBubbleMenu.updateSettings();
+        }
     }
 
     /**
@@ -211,15 +218,11 @@ export default class HiWordsPlugin extends Plugin {
      * 卸载插件
      */
     onunload() {
-        // definitionPopover 作为子组件会自动卸载
         this.vocabularyManager.clear();
-        // 清理增量更新相关资源
         if (this.vocabularyManager.destroy) {
             this.vocabularyManager.destroy();
         }
-        // 清理全局高亮器管理器
         highlighterManager.clear();
-        // 清理 PDF 高亮器资源
         cleanupPDFHighlighter(this);
     }
 }

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -181,4 +181,20 @@ export default {
         network_error: "🌐 Netzwerkverbindung fehlgeschlagen. Bitte überprüfen Sie Ihre Netzwerkeinstellungen",
         request_failed: "KI-Wörterbuch-Anfrage fehlgeschlagen",
     },
+    
+    selection_bubble: {
+        lookup: "Nachschlagen",
+        translate: "Übersetzen",
+        grammar: "Grammatik",
+        add_to_vocab: "Zum Vokabular hinzufügen",
+        dictionary_not_configured: "Wörterbuchdienst nicht konfiguriert",
+        translation_not_configured: "Übersetzungsdienst nicht konfiguriert",
+        grammar_not_configured: "Grammatikanalyse nicht konfiguriert",
+        lookup_failed: "Wörterbuchsuche fehlgeschlagen",
+        translation_failed: "Übersetzung fehlgeschlagen",
+        grammar_failed: "Grammatikanalyse fehlgeschlagen",
+        looking_up: "Suche läuft...",
+        translating: "Übersetzung läuft...",
+        analyzing: "Grammatikanalyse läuft...",
+    },
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -81,6 +81,13 @@ export default {
         mode_filename: "Filename only",
         mode_content: "File content only",
         mode_filename_with_alias: "Filename as word, content as alias",
+        // Selection bubble menu settings
+        selection_bubble_menu: "AI Selection Bubble Menu",
+        enable_selection_bubble: "Enable AI selection Menu",
+        enable_selection_bubble_desc: "Show a AI selection when you select text, with dictionary lookup, translation, and grammar analysis tools",
+        
+        ai_output_language: "AI Assistant Output Language",
+        ai_output_language_desc: "Display language for AI dictionary and grammar analysis results",
     },
     
     // Sidebar
@@ -155,6 +162,7 @@ export default {
         definition_label: "Definition",
         book_label: "Vocabulary book",
         select_book: "Select a vocabulary book",
+        please_select_book: "Please select a vocabulary book",
         color_label: "Card color",
         color_gray: "Gray",
         color_red: "Red",
@@ -195,4 +203,69 @@ export default {
         network_error: "🌐 Network connection failed. Please check your network settings",
         request_failed: "AI dictionary request failed",
     },
+    
+    selection_bubble: {
+        lookup: "Look up",
+        translate: "Translate",
+        grammar: "Grammar",
+        add_to_vocab: "Add to vocabulary",
+        dictionary_not_configured: "Dictionary service not configured",
+        translation_not_configured: "Translation service not configured",
+        grammar_not_configured: "Grammar analysis not configured",
+        lookup_failed: "Dictionary lookup failed",
+        translation_failed: "Translation failed",
+        grammar_failed: "Grammar analysis failed",
+        looking_up: "Looking up...",
+        translating: "Translating...",
+        analyzing: "Analyzing grammar...",
+    },
+    
+    dictionary: {
+        word_empty: "Word cannot be empty",
+        word_not_found: "Word not found",
+        api_error: "API request failed",
+        invalid_response: "Invalid response data",
+        network_error: "Network error",
+        provider_not_configured: "Dictionary provider not configured",
+        custom_url_required: "Custom API URL is required",
+        play_pronunciation: "Play pronunciation",
+        synonyms: "Synonyms",
+        antonyms: "Antonyms",
+        no_definition_found: "No definition found",
+        view_source: "View source",
+        add_to_vocabulary: "Add to vocabulary",
+        loading: "Loading...",
+        lookup_failed: "Dictionary lookup failed",
+    },
+    
+    translation: {
+        title: "Translation",
+        text_empty: "Text cannot be empty",
+        text_too_long: "Text too long (max 5000 characters)",
+        provider_not_supported: "Translation provider not supported",
+        api_error: "Translation API failed",
+        network_error: "Network error",
+        invalid_response: "Invalid response data",
+        api_key_required: "API Key is required",
+        original_text: "Original",
+        translated_text: "Translation",
+        translating: "Translating...",
+    },
+    
+    grammar: {
+        title: "Grammar Analysis",
+        text_empty: "Text cannot be empty",
+        text_too_long: "Text too long (max 2000 characters)",
+        analysis_failed: "Grammar analysis failed",
+        original_text: "Original Text",
+        analysis_result: "Analysis Result",
+    },
+    
+    common: {
+        close: "Close",
+        copy: "Copy",
+        copied: "Copied",
+    },
 }
+    
+    // Selection bubble menu

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -183,4 +183,20 @@ export default {
         network_error: "🌐 Fallo en la conexión de red. Por favor, verifique su configuración de red",
         request_failed: "Solicitud al diccionario AI falló",
     },
+    
+    selection_bubble: {
+        lookup: "Buscar",
+        translate: "Traducir",
+        grammar: "Gramática",
+        add_to_vocab: "Agregar al vocabulario",
+        dictionary_not_configured: "Servicio de diccionario no configurado",
+        translation_not_configured: "Servicio de traducción no configurado",
+        grammar_not_configured: "Análisis gramatical no configurado",
+        lookup_failed: "Búsqueda en diccionario falló",
+        translation_failed: "Traducción falló",
+        grammar_failed: "Análisis gramatical falló",
+        looking_up: "Buscando...",
+        translating: "Traduciendo...",
+        analyzing: "Analizando gramática...",
+    },
 }

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -183,4 +183,20 @@ export default {
         network_error: "🌐 Échec de la connexion réseau. Veuillez vérifier vos paramètres réseau",
         request_failed: "La requête au dictionnaire IA a échoué",
     },
+    
+    selection_bubble: {
+        lookup: "Rechercher",
+        translate: "Traduire",
+        grammar: "Grammaire",
+        add_to_vocab: "Ajouter au vocabulaire",
+        dictionary_not_configured: "Service de dictionnaire non configuré",
+        translation_not_configured: "Service de traduction non configuré",
+        grammar_not_configured: "Analyse grammaticale non configurée",
+        lookup_failed: "Recherche dans le dictionnaire échouée",
+        translation_failed: "Traduction échouée",
+        grammar_failed: "Analyse grammaticale échouée",
+        looking_up: "Recherche en cours...",
+        translating: "Traduction en cours...",
+        analyzing: "Analyse grammaticale en cours...",
+    },
 }

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -181,4 +181,20 @@ export default {
         network_error: "🌐 ネットワーク接続に失敗しました。ネットワーク設定を確認してください",
         request_failed: "AI辞書リクエストが失敗しました",
     },
+    
+    selection_bubble: {
+        lookup: "辞書検索",
+        translate: "翻訳",
+        grammar: "文法",
+        add_to_vocab: "単語帳に追加",
+        dictionary_not_configured: "辞書サービスが設定されていません",
+        translation_not_configured: "翻訳サービスが設定されていません",
+        grammar_not_configured: "文法分析が設定されていません",
+        lookup_failed: "辞書検索に失敗しました",
+        translation_failed: "翻訳に失敗しました",
+        grammar_failed: "文法分析に失敗しました",
+        looking_up: "検索中...",
+        translating: "翻訳中...",
+        analyzing: "文法分析中...",
+    },
 }

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -81,6 +81,13 @@ export default {
         mode_filename: "仅文件名",
         mode_content: "仅文件内容",
         mode_filename_with_alias: "文件名作为主词，内容作为别名",
+        // I取词菜单设置
+        selection_bubble_menu: "AI取词",
+        enable_selection_bubble: "启用AI取词",
+        enable_selection_bubble_desc: "选中文本后显示取词菜单，提供查词、翻译和语法分析工具（需要先配置大模型API）",
+   
+        ai_output_language: "AI 助手输出语言",
+        ai_output_language_desc: "AI 查词和语法分析结果的显示语言",
     },
     
     // 侧边栏
@@ -155,6 +162,7 @@ export default {
         definition_label: "释义",
         book_label: "单词本",
         select_book: "选择单词本",
+        please_select_book: "请选择单词本",
         color_label: "卡片颜色",
         color_gray: "灰色",
         color_red: "红色",
@@ -195,4 +203,67 @@ export default {
         network_error: "🌐 网络连接失败,请检查网络设置",
         request_failed: "AI 词典请求失败",
     },
-}
+    
+    selection_bubble: {
+        lookup: "查词",
+        translate: "翻译",
+        grammar: "语法分析",
+        add_to_vocab: "添加到单词本",
+        dictionary_not_configured: "词典功能未配置",
+        translation_not_configured: "翻译功能未配置",
+        grammar_not_configured: "语法分析功能未配置",
+        lookup_failed: "查词失败",
+        translation_failed: "翻译失败",
+        grammar_failed: "语法分析失败",
+        looking_up: "查询中...",
+        translating: "翻译中...",
+        analyzing: "语法分析中...",
+    },
+    
+    dictionary: {
+        word_empty: "单词不能为空",
+        word_not_found: "未找到该单词",
+        api_error: "API 请求失败",
+        invalid_response: "无效的响应数据",
+        network_error: "网络错误",
+        provider_not_configured: "词典服务未配置",
+        custom_url_required: "自定义 API 地址必填",
+        play_pronunciation: "播放发音",
+        synonyms: "同义词",
+        antonyms: "反义词",
+        no_definition_found: "未找到释义",
+        view_source: "查看来源",
+        add_to_vocabulary: "添加到单词本",
+        loading: "加载中...",
+        lookup_failed: "查词失败",
+    },
+    
+    translation: {
+        title: "翻译结果",
+        text_empty: "翻译文本不能为空",
+        text_too_long: "翻译文本过长（最多 5000 字符）",
+        provider_not_supported: "不支持的翻译服务",
+        api_error: "翻译 API 请求失败",
+        network_error: "网络错误",
+        invalid_response: "无效的响应数据",
+        api_key_required: "API Key 是必需的",
+        original_text: "原文",
+        translated_text: "译文",
+        translating: "翻译中...",
+    },
+    
+    grammar: {
+        title: "语法分析",
+        text_empty: "分析文本不能为空",
+        text_too_long: "分析文本过长（最多 2000 字符）",
+        analysis_failed: "语法分析失败",
+        original_text: "原文",
+        analysis_result: "分析结果",
+    },
+    
+    common: {
+        close: "关闭",
+        copy: "复制",
+        copied: "已复制",
+    },
+};

--- a/src/services/dictionary-lookup-service.ts
+++ b/src/services/dictionary-lookup-service.ts
@@ -1,0 +1,142 @@
+import type { DictionaryResult } from '../utils';
+import { t } from '../i18n';
+import { DictionaryService } from './dictionary-service';
+
+export class DictionaryLookupService {
+    private dictionaryService: DictionaryService;
+    private outputLanguage: string;
+
+    constructor(
+        aiConfig: { apiUrl: string; apiKey: string; model: string; prompt: string },
+        outputLanguage: string = 'zh'
+    ) {
+        this.dictionaryService = new DictionaryService(aiConfig);
+        this.outputLanguage = outputLanguage;
+    }
+
+    async lookupWordStream(
+        word: string,
+        onChunk: (content: string) => void,
+        onComplete: () => void,
+        onError: (error: Error) => void
+    ): Promise<void> {
+        if (!word || typeof word !== 'string') {
+            onError(new Error(t('dictionary.word_empty')));
+            return;
+        }
+        
+        const cleanWord = word.trim().toLowerCase();
+        
+        if (!cleanWord) {
+            onError(new Error(t('dictionary.word_empty')));
+            return;
+        }
+
+        const prompt = this.buildLookupPrompt(cleanWord);
+        await this.dictionaryService.makeAIRequestStream(prompt, onChunk, onComplete, onError);
+    }
+
+    async lookupWord(word: string): Promise<DictionaryResult> {
+        if (!word || typeof word !== 'string') {
+            throw new Error(t('dictionary.word_empty'));
+        }
+        
+        const cleanWord = word.trim().toLowerCase();
+        
+        if (!cleanWord) {
+            throw new Error(t('dictionary.word_empty'));
+        }
+
+        return await this.lookupWithAI(cleanWord);
+    }
+
+    private buildLookupPrompt(word: string): string {
+        return `Please provide a concise dictionary definition for the word "${word}" in well-formatted Markdown. Please provide definitions in ${this.outputLanguage}, but keep example sentences in English.
+
+Format:
+
+${word} /phonetic transcription/
+
+[Part of Speech]
+1. Main definition (most common usage)
+   - *Example: "example sentence in English"*
+
+2. Secondary definition (if commonly used)
+   - *Example: "example sentence in English"*
+
+Requirements:
+- Include phonetic transcription
+- Focus on the 2-3 most common meanings only
+- only Definitions in ${this.outputLanguage}
+- Part of Speech should be in English
+- Provide ONE clear example sentence per definition
+- Keep content concise and suitable for vocabulary card recording
+- NO synonyms or antonyms needed
+- Use clear Markdown formatting`;
+    }
+
+    private async lookupWithAI(word: string): Promise<DictionaryResult> {
+        const prompt = this.buildLookupPrompt(word);
+
+        try {
+            const cacheKey = `lookup:${word}:${this.outputLanguage}`;
+            const content = await this.dictionaryService.makeAIRequest(prompt, cacheKey, true);
+            const result = this.parseAIResponse(content);
+            return result;
+        } catch (error) {
+            if (error instanceof Error) {
+                throw error;
+            }
+            throw new Error(t('dictionary.network_error'));
+        }
+    }
+
+    private parseAIResponse(content: string): DictionaryResult {
+        try {
+            const data = JSON.parse(content);
+
+            if (!data.word || !data.meanings || !Array.isArray(data.meanings)) {
+                throw new Error('Invalid AI response format');
+            }
+
+            const result: DictionaryResult = {
+                word: data.word,
+                meanings: []
+            };
+
+            if (data.phonetic) {
+                result.phonetic = data.phonetic;
+            }
+
+            if (data.phonetics && Array.isArray(data.phonetics)) {
+                result.phonetics = data.phonetics
+                    .filter((p: any) => p.text || p.audio)
+                    .map((p: any) => ({
+                        text: p.text,
+                        audio: p.audio
+                    }));
+            }
+
+            if (data.meanings && Array.isArray(data.meanings)) {
+                result.meanings = data.meanings.map((meaning: any) => ({
+                    partOfSpeech: meaning.partOfSpeech || '',
+                    definitions: (meaning.definitions || []).map((def: any) => ({
+                        definition: def.definition || '',
+                        example: def.example,
+                        synonyms: def.synonyms || [],
+                        antonyms: def.antonyms || []
+                    }))
+                }));
+            }
+
+            if (data.sourceUrl) {
+                result.sourceUrl = data.sourceUrl;
+            }
+
+            return result;
+        } catch (error) {
+            console.error('Failed to parse AI response:', content, error);
+            throw new Error(t('dictionary.invalid_response'));
+        }
+    }
+}

--- a/src/services/dictionary-service.ts
+++ b/src/services/dictionary-service.ts
@@ -14,9 +14,10 @@ type APIType = 'openai' | 'claude' | 'gemini';
  * API 配置接口
  */
 interface APIAdapter {
-    buildRequest: (model: string, prompt: string) => any;
+    buildRequest: (model: string, prompt: string, stream?: boolean) => any;
     buildHeaders: (apiKey: string) => Record<string, string>;
     extractResponse: (data: any) => string | undefined;
+    extractStreamContent?: (line: string) => string | null;
     buildUrl?: (baseUrl: string, model: string, apiKey: string) => string;
 }
 
@@ -34,7 +35,7 @@ interface CacheEntry {
 export class DictionaryService {
     private config: AIConfig;
     private cache = new Map<string, CacheEntry>();
-    private readonly CACHE_TTL = 24 * 60 * 60 * 1000; // 24小时
+    private readonly CACHE_TTL = 24 * 60 * 60 * 1000;
     private readonly MAX_RETRIES = 3;
 
     /**
@@ -42,38 +43,74 @@ export class DictionaryService {
      */
     private readonly API_ADAPTERS: Record<APIType, APIAdapter> = {
         openai: {
-            buildRequest: (model: string, prompt: string) => ({
+            buildRequest: (model: string, prompt: string, stream: boolean = false) => ({
                 model,
                 messages: [{ role: 'user', content: prompt }],
                 temperature: 0.3,
-                max_tokens: 500
+                max_tokens: 500,
+                ...(stream && { stream: true })
             }),
             buildHeaders: (apiKey: string) => ({
                 'Authorization': `Bearer ${apiKey}`
             }),
-            extractResponse: (data: any) => data?.choices?.[0]?.message?.content
+            extractResponse: (data: any) => data?.choices?.[0]?.message?.content,
+            extractStreamContent: (line: string) => {
+                if (!line.startsWith('data: ')) return null;
+                const data = line.slice(6);
+                if (data === '[DONE]') return null;
+                
+                try {
+                    const parsed = JSON.parse(data);
+                    return parsed.choices?.[0]?.delta?.content || null;
+                } catch {
+                    return null;
+                }
+            }
         },
         claude: {
-            buildRequest: (model: string, prompt: string) => ({
+            buildRequest: (model: string, prompt: string, stream: boolean = false) => ({
                 model,
                 messages: [{ role: 'user', content: prompt }],
-                max_tokens: 1024
+                max_tokens: 1024,
+                ...(stream && { stream: true })
             }),
             buildHeaders: (apiKey: string) => ({
                 'x-api-key': apiKey,
                 'anthropic-version': '2023-06-01'
             }),
-            extractResponse: (data: any) => data?.content?.[0]?.text
+            extractResponse: (data: any) => data?.content?.[0]?.text,
+            extractStreamContent: (line: string) => {
+                if (!line.startsWith('data: ')) return null;
+                const data = line.slice(6);
+                
+                try {
+                    const parsed = JSON.parse(data);
+                    if (parsed.type === 'content_block_delta') {
+                        return parsed.delta?.text || null;
+                    }
+                    return null;
+                } catch {
+                    return null;
+                }
+            }
         },
         gemini: {
-            buildRequest: (model: string, prompt: string) => ({
+            buildRequest: (model: string, prompt: string, stream: boolean = false) => ({
                 contents: [{ parts: [{ text: prompt }] }]
             }),
             buildHeaders: () => ({}),
             extractResponse: (data: any) => data?.candidates?.[0]?.content?.parts?.[0]?.text,
+            extractStreamContent: (line: string) => {
+                try {
+                    const parsed = JSON.parse(line);
+                    return parsed.candidates?.[0]?.content?.parts?.[0]?.text || null;
+                } catch {
+                    return null;
+                }
+            },
             buildUrl: (baseUrl: string, model: string, apiKey: string) => {
                 let url = baseUrl;
-                if (!url.includes(':generateContent')) {
+                if (!url.includes(':generateContent') && !url.includes(':streamGenerateContent')) {
                     url = `${url.replace(/\/$/, '')}/models/${model}:generateContent`;
                 }
                 return `${url}?key=${apiKey}`;
@@ -104,9 +141,9 @@ export class DictionaryService {
     }
 
     /**
-     * 验证 AI 配置是否有效
+     * 验证 AI 配置是否有效（可选验证 prompt 占位符）
      */
-    private validateConfig(): { isValid: boolean; error?: string } {
+    private validateConfig(requireWordPlaceholder: boolean = true): { isValid: boolean; error?: string } {
         if (!this.config.apiUrl?.trim()) {
             return { isValid: false, error: t('ai_errors.api_url_required') };
         }
@@ -130,8 +167,8 @@ export class DictionaryService {
             return { isValid: false, error: t('ai_errors.invalid_api_url') };
         }
         
-        // 验证 prompt 包含必要的占位符
-        if (!this.config.prompt.includes('{{word}}')) {
+        // 验证 prompt 包含必要的占位符（可选）
+        if (requireWordPlaceholder && !this.config.prompt.includes('{{word}}')) {
             return { isValid: false, error: t('ai_errors.prompt_missing_word_placeholder') };
         }
         
@@ -148,37 +185,114 @@ export class DictionaryService {
     }
 
     /**
-     * 获取单词释义
-     * @param word 要查询的单词
-     * @param sentence 单词所在的句子（可选）
-     * @returns 释义文本
+     * 通用 AI 请求方法（供其他服务复用）
+     * @param prompt 完整的提示词
+     * @param cacheKey 缓存键（可选，不传则不使用缓存）
+     * @param useCache 是否使用缓存（默认 true）
+     * @returns AI 响应内容
      */
-    async fetchDefinition(word: string, sentence?: string): Promise<string> {
-        // 参数验证
-        if (!word?.trim()) {
-            throw new Error(t('ai_errors.word_empty'));
+    async makeAIRequestStream(
+        prompt: string,
+        onChunk: (content: string) => void,
+        onComplete: () => void,
+        onError: (error: Error) => void
+    ): Promise<void> {
+        const validation = this.validateConfig(false);
+        if (!validation.isValid) {
+            onError(new Error(validation.error!));
+            return;
         }
 
-        // 配置验证
-        const validation = this.validateConfig();
+        const apiType = this.detectAPIType();
+        const adapter = this.API_ADAPTERS[apiType];
+
+        if (!adapter.extractStreamContent) {
+            onError(new Error('Streaming not supported for this API type'));
+            return;
+        }
+
+        let url = this.config.apiUrl;
+        if (adapter.buildUrl) {
+            url = adapter.buildUrl(this.config.apiUrl, this.config.model, this.config.apiKey);
+            if (apiType === 'gemini' && !url.includes(':streamGenerateContent')) {
+                url = url.replace(':generateContent', ':streamGenerateContent');
+                if (!url.includes('alt=sse')) {
+                    url += (url.includes('?') ? '&' : '?') + 'alt=sse';
+                }
+            }
+        }
+
+        const headers = adapter.buildHeaders(this.config.apiKey);
+        const body = adapter.buildRequest(this.config.model, prompt, true);
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...headers
+                },
+                body: JSON.stringify(body)
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+
+            const reader = response.body?.getReader();
+            if (!reader) {
+                throw new Error('Response body is not readable');
+            }
+
+            const decoder = new TextDecoder();
+            let buffer = '';
+
+            while (true) {
+                const { done, value } = await reader.read();
+                
+                if (done) {
+                    onComplete();
+                    break;
+                }
+
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split('\n');
+                buffer = lines.pop() || '';
+
+                for (const line of lines) {
+                    const trimmedLine = line.trim();
+                    if (!trimmedLine) continue;
+
+                    const content = adapter.extractStreamContent!(trimmedLine);
+                    if (content) {
+                        onChunk(content);
+                    }
+                }
+            }
+        } catch (error) {
+            onError(error instanceof Error ? error : new Error(String(error)));
+        }
+    }
+
+    async makeAIRequest(prompt: string, cacheKey?: string, useCache: boolean = true): Promise<string> {
+        // 配置验证（不要求 prompt 占位符）
+        const validation = this.validateConfig(false);
         if (!validation.isValid) {
             throw new Error(validation.error!);
         }
 
-        const cleanWord = word.trim();
-        const cacheKey = `${cleanWord}:${sentence || ''}`;
-
         // 检查缓存
-        const cached = this.cache.get(cacheKey);
-        if (cached && Date.now() - cached.timestamp < this.CACHE_TTL) {
-            return cached.content;
+        if (useCache && cacheKey) {
+            const cached = this.cache.get(cacheKey);
+            if (cached && Date.now() - cached.timestamp < this.CACHE_TTL) {
+                return cached.content;
+            }
         }
 
         try {
             // 检测 API 类型并获取适配器
             const apiType = this.detectAPIType();
             const adapter = this.API_ADAPTERS[apiType];
-            const prompt = this.replacePlaceholders(cleanWord, sentence);
 
             // 构建请求参数
             const url = adapter.buildUrl 
@@ -199,12 +313,39 @@ export class DictionaryService {
             const result = content.trim();
             
             // 存入缓存
-            this.cache.set(cacheKey, { content: result, timestamp: Date.now() });
+            if (useCache && cacheKey) {
+                this.cache.set(cacheKey, { content: result, timestamp: Date.now() });
+            }
             
             return result;
         } catch (error) {
             throw this.handleError(error);
         }
+    }
+
+    /**
+     * 获取单词释义
+     * @param word 要查询的单词
+     * @param sentence 单词所在的句子（可选）
+     * @returns 释义文本
+     */
+    async fetchDefinition(word: string, sentence?: string): Promise<string> {
+        // 参数验证
+        if (!word?.trim()) {
+            throw new Error(t('ai_errors.word_empty'));
+        }
+
+        // 配置验证
+        const validation = this.validateConfig(true);
+        if (!validation.isValid) {
+            throw new Error(validation.error!);
+        }
+
+        const cleanWord = word.trim();
+        const prompt = this.replacePlaceholders(cleanWord, sentence);
+        const cacheKey = `${cleanWord}:${sentence || ''}`;
+
+        return this.makeAIRequest(prompt, cacheKey, true);
     }
 
     /**

--- a/src/services/grammar-analysis-service.ts
+++ b/src/services/grammar-analysis-service.ts
@@ -1,0 +1,74 @@
+import { DictionaryService } from './dictionary-service';
+import { t } from '../i18n';
+
+export class GrammarAnalysisService {
+    private dictionaryService: DictionaryService;
+    private outputLanguage: string;
+
+    constructor(
+        aiConfig: { apiUrl: string; apiKey: string; model: string; prompt: string },
+        outputLanguage: string = 'zh'
+    ) {
+        this.dictionaryService = new DictionaryService(aiConfig);
+        this.outputLanguage = outputLanguage;
+    }
+
+    async analyzeGrammarStream(
+        text: string,
+        onChunk: (content: string) => void,
+        onComplete: () => void,
+        onError: (error: Error) => void
+    ): Promise<void> {
+        const cleanText = text.trim();
+        
+        if (!cleanText) {
+            onError(new Error(t('grammar.text_empty')));
+            return;
+        }
+
+        if (cleanText.length > 2000) {
+            onError(new Error(t('grammar.text_too_long')));
+            return;
+        }
+
+        const prompt = this.buildAnalysisPrompt(cleanText);
+        await this.dictionaryService.makeAIRequestStream(prompt, onChunk, onComplete, onError);
+    }
+
+    async analyzeGrammar(text: string): Promise<string> {
+        const cleanText = text.trim();
+        
+        if (!cleanText) {
+            throw new Error(t('grammar.text_empty'));
+        }
+
+        if (cleanText.length > 2000) {
+            throw new Error(t('grammar.text_too_long'));
+        }
+
+        const prompt = this.buildAnalysisPrompt(cleanText);
+
+        try {
+            const cacheKey = `grammar:${cleanText}:${this.outputLanguage}`;
+            return await this.dictionaryService.makeAIRequest(prompt, cacheKey, true);
+        } catch (error) {
+            if (error instanceof Error) {
+                throw error;
+            }
+            throw new Error(t('grammar.analysis_failed'));
+        }
+    }
+
+    private buildAnalysisPrompt(text: string): string {
+        return `Analyze the grammar structure of the following text and provide a concise explanation in ${this.outputLanguage}. DO NOT repeat the original sentence in your response.
+
+"${text}"
+
+Please provide:
+1. **Sentence Structure**: Subject, verb, object, and key components
+2. **Grammar Points**: Important grammar patterns used
+3. **Key Notes**: Any notable points or common mistakes to avoid
+
+Format: Clear, concise Markdown. Keep explanations brief and focused.`;
+    }
+}

--- a/src/services/translation-service.ts
+++ b/src/services/translation-service.ts
@@ -1,0 +1,106 @@
+import type { TranslationResult } from '../utils';
+import { t } from '../i18n';
+import { DictionaryService } from './dictionary-service';
+
+export class TranslationService {
+    private dictionaryService: DictionaryService;
+    private targetLanguage: string;
+
+    constructor(
+        aiConfig: { apiUrl: string; apiKey: string; model: string; prompt: string },
+        targetLanguage: string = 'chinese (Simplified)',
+    ) {
+        this.dictionaryService = new DictionaryService(aiConfig);
+        this.targetLanguage = targetLanguage;
+    }
+
+    async translateStream(
+        text: string,
+        onChunk: (content: string) => void,
+        onComplete: () => void,
+        onError: (error: Error) => void
+    ): Promise<void> {
+        const cleanText = text.trim();
+        
+        if (!cleanText) {
+            onError(new Error(t('translation.text_empty')));
+            return;
+        }
+
+        if (cleanText.length > 5000) {
+            onError(new Error(t('translation.text_too_long')));
+            return;
+        }
+
+        const prompt = `Translate the following text to ${this.targetLanguage}. Provide ONLY the translated text, no explanations or additional formatting:
+
+${cleanText}`;
+
+        await this.dictionaryService.makeAIRequestStream(prompt, onChunk, onComplete, onError);
+    }
+
+    async translate(text: string): Promise<TranslationResult> {
+        const cleanText = text.trim();
+        
+        if (!cleanText) {
+            throw new Error(t('translation.text_empty'));
+        }
+
+        if (cleanText.length > 5000) {
+            throw new Error(t('translation.text_too_long'));
+        }
+
+        return await this.translateWithAI(cleanText);
+    }
+
+    private async translateWithAI(text: string): Promise<TranslationResult> {
+        const prompt = `Please translate the following text to ${this.targetLanguage} and return the result in the following exact JSON format. Do not include any additional text or explanations outside the JSON structure:
+
+{
+  "originalText": "${text}",
+  "translatedText": "translated text here",
+  "targetLanguage": "${this.targetLanguage}"
+}
+
+Requirements:
+- Return ONLY valid JSON, no markdown formatting or code blocks
+- Provide accurate translation
+- Ensure the translation is natural and fluent in the target language`;
+
+        try {
+            const content = await this.dictionaryService.makeAIRequest(prompt, `translate:${text}`, true);
+            const result = this.parseAIResponse(content);
+            return result;
+        } catch (error) {
+            if (error instanceof Error) {
+                throw error;
+            }
+            throw new Error(t('translation.network_error'));
+        }
+    }
+
+    private parseAIResponse(content: string): TranslationResult {
+        try {
+            const data = JSON.parse(content);
+
+            if (!data.originalText || !data.translatedText || !data.targetLanguage) {
+                throw new Error('Invalid AI response format');
+            }
+
+            const result: TranslationResult = {
+                originalText: data.originalText,
+                translatedText: data.translatedText,
+                targetLanguage: data.targetLanguage
+            };
+
+            if (data.detectedLanguage) {
+                result.detectedLanguage = data.detectedLanguage;
+            }
+
+            return result;
+        } catch (error) {
+            console.error('Failed to parse AI response:', content, error);
+            throw new Error(t('translation.invalid_response'));
+        }
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -29,5 +29,8 @@ export const DEFAULT_SETTINGS: HiWordsSettings = {
     highlightMode: 'all',
     highlightPaths: '',
     // 文件节点解析模式
-    fileNodeParseMode: 'filename-with-alias'
+    fileNodeParseMode: 'filename-with-alias',
+    // 文本选择气泡菜单配置
+    selectionBubble: true,
+    aiOutputLanguage: 'Chinese (Simplified)'
 };

--- a/src/ui/dictionary-result-modal.ts
+++ b/src/ui/dictionary-result-modal.ts
@@ -1,0 +1,181 @@
+import { App, Modal, setIcon, Notice } from 'obsidian';
+import type HiWordsPlugin from '../../main';
+import { playWordTTS } from '../utils';
+import { t } from '../i18n';
+import { AddWordModal } from './add-word-modal';
+import { renderMarkdownToHTML } from '../utils/markdown-renderer';
+
+export class DictionaryResultModal extends Modal {
+    private plugin: HiWordsPlugin;
+    private word: string;
+    private contentContainer!: HTMLElement;
+    private isStreaming: boolean = false;
+    private streamBuffer: string = '';
+    private selectedBookPath: string = '';
+    private addButton!: HTMLElement;
+    private bookSelect!: HTMLSelectElement;
+    private isWordSaved: boolean = false;
+
+    constructor(app: App, plugin: HiWordsPlugin, word: string) {
+        super(app);
+        this.plugin = plugin;
+        this.word = word;
+        this.checkIfWordExists();
+    }
+
+    private checkIfWordExists() {
+        const definition = this.plugin.vocabularyManager.getDefinition(this.word);
+        if (definition) {
+            this.isWordSaved = true;
+            this.selectedBookPath = definition.source;
+        }
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass('hiwords-dictionary-modal');
+
+        const headerEl = contentEl.createDiv({ cls: 'hiwords-modal-header' });
+        
+        const titleContainer = headerEl.createDiv({ cls: 'hiwords-modal-title-container' });
+        titleContainer.createEl('h2', { text: this.word, cls: 'hiwords-modal-title' });
+
+        const actionsContainer = headerEl.createDiv({ cls: 'hiwords-modal-actions' });
+
+        if (this.plugin.settings.ttsTemplate) {
+            const playButton = actionsContainer.createDiv({ cls: 'hiwords-play-button' });
+            setIcon(playButton, 'volume-2');
+            playButton.setAttribute('aria-label', t('dictionary.play_pronunciation'));
+            
+            playButton.addEventListener('click', async () => {
+                await playWordTTS(this.plugin, this.word);
+            });
+        }
+
+        const bookSelectContainer = actionsContainer.createDiv({ cls: 'hiwords-book-select-container' });
+        this.bookSelect = bookSelectContainer.createEl('select', { cls: 'dropdown hiwords-book-select' });
+        
+        this.bookSelect.createEl('option', { text: t('modals.select_book'), value: '' });
+        
+        const enabledBooks = this.plugin.settings.vocabularyBooks.filter(book => book.enabled);
+        enabledBooks.forEach((book) => {
+            const option = this.bookSelect.createEl('option', { text: book.name, value: book.path });
+            if (this.isWordSaved && book.path === this.selectedBookPath) {
+                option.selected = true;
+            }
+        });
+
+        this.bookSelect.addEventListener('change', (e) => {
+            this.selectedBookPath = (e.target as HTMLSelectElement).value;
+        });
+
+        this.addButton = actionsContainer.createDiv({ cls: 'hiwords-add-button' });
+        setIcon(this.addButton, 'star');
+        this.addButton.setAttribute('aria-label', t('dictionary.add_to_vocabulary'));
+        
+        if (this.isWordSaved) {
+            this.addButton.addClass('hiwords-word-saved');
+        }
+        
+        this.addButton.addEventListener('click', async () => {
+            await this.handleAddToVocabulary();
+        });
+
+        this.contentContainer = contentEl.createDiv({ cls: 'hiwords-modal-content' });
+        this.contentContainer.createDiv({ 
+            text: t('dictionary.loading'), 
+            cls: 'hiwords-loading' 
+        });
+    }
+
+    private async handleAddToVocabulary() {
+        if (!this.selectedBookPath) {
+            new Notice(t('modals.please_select_book'));
+            return;
+        }
+
+        const definition = this.streamBuffer || '';
+        
+        const modal = new AddWordModal(
+            this.app,
+            this.plugin,
+            this.word,
+            '',
+            this.isWordSaved
+        );
+        
+        modal.open();
+        
+        setTimeout(() => {
+            const bookSelect = modal.contentEl.querySelector('select.dropdown') as HTMLSelectElement;
+            if (bookSelect) {
+                bookSelect.value = this.selectedBookPath;
+            }
+            
+            const definitionTextarea = modal.contentEl.querySelector('textarea') as HTMLTextAreaElement;
+            if (definitionTextarea && !this.isWordSaved) {
+                definitionTextarea.value = definition;
+            }
+        }, 100);
+
+        modal.onClose = () => {
+            this.updateSaveStatus();
+        };
+    }
+
+    private updateSaveStatus() {
+        const definition = this.plugin.vocabularyManager.getDefinition(this.word);
+        if (definition && !this.isWordSaved) {
+            this.isWordSaved = true;
+            this.selectedBookPath = definition.source;
+            this.addButton.addClass('hiwords-word-saved');
+            
+            if (this.bookSelect) {
+                this.bookSelect.value = this.selectedBookPath;
+            }
+        }
+    }
+
+    startStreaming() {
+        this.isStreaming = true;
+        this.streamBuffer = '';
+        this.contentContainer.empty();
+        this.contentContainer.createDiv({ cls: 'hiwords-streaming-content' });
+    }
+
+    appendStreamChunk(chunk: string) {
+        if (!this.isStreaming) return;
+        
+        this.streamBuffer += chunk;
+        
+        const streamingDiv = this.contentContainer.querySelector('.hiwords-streaming-content');
+        if (streamingDiv) {
+            streamingDiv.empty();
+            streamingDiv.createDiv().innerHTML = renderMarkdownToHTML(this.streamBuffer);
+        }
+    }
+
+    completeStreaming() {
+        this.isStreaming = false;
+        
+        const streamingDiv = this.contentContainer.querySelector('.hiwords-streaming-content');
+        if (streamingDiv) {
+            streamingDiv.addClass('hiwords-stream-complete');
+        }
+    }
+
+    showError(error: string) {
+        this.isStreaming = false;
+        this.contentContainer.empty();
+        this.contentContainer.createEl('p', { 
+            text: error, 
+            cls: 'hiwords-error' 
+        });
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/ui/grammar-analysis-modal.ts
+++ b/src/ui/grammar-analysis-modal.ts
@@ -1,0 +1,98 @@
+import { App, Modal, Component } from 'obsidian';
+import { t } from '../i18n';
+import { renderMarkdownToElement } from '../utils/markdown-renderer';
+
+export class GrammarAnalysisModal extends Modal {
+    private originalText: string;
+    private analysisResult: string = '';
+    private analysisContent: HTMLElement | null = null;
+    private tempComponent: Component | null = null;
+    private isStreaming: boolean = false;
+
+    constructor(app: App, originalText: string) {
+        super(app);
+        this.originalText = originalText;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass('hiwords-grammar-modal');
+
+        const headerEl = contentEl.createDiv({ cls: 'hiwords-modal-header' });
+        headerEl.createEl('h2', { text: t('grammar.title'), cls: 'hiwords-modal-title' });
+
+        const contentContainer = contentEl.createDiv({ cls: 'hiwords-modal-content' });
+
+        const originalSection = contentContainer.createDiv({ cls: 'hiwords-grammar-section' });
+        originalSection.createEl('h3', { text: t('grammar.original_text'), cls: 'hiwords-section-title' });
+        originalSection.createEl('div', { 
+            text: this.originalText, 
+            cls: 'hiwords-grammar-original' 
+        });
+
+        const analysisSection = contentContainer.createDiv({ cls: 'hiwords-grammar-section' });
+        analysisSection.createEl('h3', { text: t('grammar.analysis_result'), cls: 'hiwords-section-title' });
+        
+        this.analysisContent = analysisSection.createDiv({ cls: 'hiwords-grammar-analysis' });
+    }
+
+    startStreaming() {
+        this.isStreaming = true;
+        this.analysisResult = '';
+        if (this.analysisContent) {
+            this.analysisContent.empty();
+            this.analysisContent.createEl('div', { 
+                text: t('selection_bubble.analyzing'), 
+                cls: 'hiwords-streaming-indicator' 
+            });
+        }
+    }
+
+    appendStreamChunk(chunk: string) {
+        if (!this.isStreaming || !this.analysisContent) return;
+        
+        this.analysisResult += chunk;
+        this.renderMarkdown(this.analysisResult);
+    }
+
+    completeStreaming() {
+        this.isStreaming = false;
+    }
+
+    showError(message: string) {
+        this.isStreaming = false;
+        if (this.analysisContent) {
+            this.analysisContent.empty();
+            this.analysisContent.createEl('div', { 
+                text: message, 
+                cls: 'hiwords-error-message' 
+            });
+        }
+    }
+
+    private async renderMarkdown(content: string) {
+        if (!this.analysisContent) return;
+
+        if (this.tempComponent) {
+            this.tempComponent.unload();
+        }
+
+        this.analysisContent.empty();
+        this.tempComponent = await renderMarkdownToElement(
+            this.app,
+            content,
+            this.analysisContent,
+            ''
+        );
+    }
+
+    onClose() {
+        if (this.tempComponent) {
+            this.tempComponent.unload();
+            this.tempComponent = null;
+        }
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -6,3 +6,8 @@ export { HiWordsSidebarView, SIDEBAR_VIEW_TYPE } from './sidebar-view';
 export { DefinitionPopover } from './definition-popover';
 export { AddWordModal } from './add-word-modal';
 export { HiWordsSettingTab } from './settings-tab';
+export { SelectionBubbleMenu } from './selection-bubble-menu';
+export { DictionaryResultModal } from './dictionary-result-modal';
+export { TranslationResultModal } from './translation-result-modal';
+export { GrammarAnalysisModal } from './grammar-analysis-modal';
+

--- a/src/ui/selection-bubble-menu.ts
+++ b/src/ui/selection-bubble-menu.ts
@@ -1,0 +1,255 @@
+import { Component, setIcon, Notice } from 'obsidian';
+import type HiWordsPlugin from '../../main';
+import { DictionaryLookupService } from '../services/dictionary-lookup-service';
+import { TranslationService } from '../services/translation-service';
+import { GrammarAnalysisService } from '../services/grammar-analysis-service';
+import { DictionaryResultModal } from './dictionary-result-modal';
+import { TranslationResultModal } from './translation-result-modal';
+import { GrammarAnalysisModal } from './grammar-analysis-modal';
+import { t } from '../i18n';
+
+export class SelectionBubbleMenu extends Component {
+    private plugin: HiWordsPlugin;
+    private bubbleEl: HTMLElement | null = null;
+    private currentSelection: string | null = null;
+    private hideTimeout: number | null = null;
+    private dictionaryService: DictionaryLookupService | null = null;
+    private translationService: TranslationService | null = null;
+    private grammarService: GrammarAnalysisService | null = null;
+
+    constructor(plugin: HiWordsPlugin) {
+        super();
+        this.plugin = plugin;
+        this.initializeServices();
+        this.registerSelectionEvents();
+    }
+
+    private initializeServices() {
+        const settings = this.plugin.settings;
+        
+        if (settings.aiDictionary) {
+            const outputLanguage = settings.aiOutputLanguage || 'Chinese (Simplified)';
+            
+            this.dictionaryService = new DictionaryLookupService(
+                settings.aiDictionary,
+                outputLanguage
+            );
+            this.translationService = new TranslationService(
+                settings.aiDictionary,outputLanguage
+            );
+            this.grammarService = new GrammarAnalysisService(
+                settings.aiDictionary,
+                outputLanguage
+            );
+        }
+    }
+
+    private registerSelectionEvents() {
+        this.registerDomEvent(document, 'mouseup', this.handleMouseUp);
+        this.registerDomEvent(document, 'selectionchange', this.handleSelectionChange);
+        this.registerDomEvent(document, 'mousedown', this.handleMouseDown);
+    }
+
+    private handleMouseUp = (event: MouseEvent) => {
+        setTimeout(() => {
+            const selection = window.getSelection();
+            const selectedText = selection?.toString().trim();
+            
+            if (selectedText && selectedText.length > 0 && selectedText.length < 1000) {
+                const range = selection?.getRangeAt(0);
+                if (range) {
+                    this.showBubbleMenu(selectedText, range);
+                }
+            } else {
+                this.hideBubbleMenu();
+            }
+        }, 10);
+    };
+
+    private handleSelectionChange = () => {
+        if (this.hideTimeout) {
+            clearTimeout(this.hideTimeout);
+            this.hideTimeout = null;
+        }
+    };
+
+    private handleMouseDown = (event: MouseEvent) => {
+        if (this.bubbleEl && !this.bubbleEl.contains(event.target as Node)) {
+            this.hideBubbleMenu();
+        }
+    };
+
+    private showBubbleMenu(text: string, range: Range) {
+        if (!this.plugin.settings.selectionBubble) {
+            return;
+        }
+
+        this.hideBubbleMenu();
+        this.currentSelection = text;
+
+        this.bubbleEl = document.createElement('div');
+        this.bubbleEl.className = 'hiwords-selection-bubble';
+
+        this.addButton('book-open', t('selection_bubble.lookup'), () => this.handleDictionaryLookup());
+        this.addButton('languages', t('selection_bubble.translate'), () => this.handleTranslation());
+        this.addButton('search', t('selection_bubble.grammar'), () => this.handleGrammarAnalysis());
+        this.addButton('bookmark-plus', t('selection_bubble.add_to_vocab'), () => this.handleAddToVocabulary());
+
+        document.body.appendChild(this.bubbleEl);
+
+        requestAnimationFrame(() => {
+            this.positionBubbleMenu(range);
+        });
+
+        this.bubbleEl.addEventListener('mouseenter', () => {
+            if (this.hideTimeout) {
+                clearTimeout(this.hideTimeout);
+                this.hideTimeout = null;
+            }
+        });
+
+        this.bubbleEl.addEventListener('mouseleave', () => {
+            this.hideTimeout = window.setTimeout(() => {
+                this.hideBubbleMenu();
+            }, 300);
+        });
+    }
+
+    private addButton(icon: string, tooltip: string, onClick: () => void) {
+        if (!this.bubbleEl) return;
+
+        const button = this.bubbleEl.createDiv({ cls: 'hiwords-bubble-button' });
+        setIcon(button, icon);
+        button.setAttribute('aria-label', tooltip);
+        button.addEventListener('click', (e) => {
+            e.stopPropagation();
+            onClick();
+        });
+    }
+
+    private positionBubbleMenu(range: Range) {
+        if (!this.bubbleEl) return;
+
+        const rect = range.getBoundingClientRect();
+        const bubbleRect = this.bubbleEl.getBoundingClientRect();
+
+        let top = rect.top - bubbleRect.height - 8;
+        let left = rect.left + (rect.width / 2) - (bubbleRect.width / 2);
+
+        if (top < 0) {
+            top = rect.bottom + 8;
+        }
+
+        if (left < 0) {
+            left = 8;
+        } else if (left + bubbleRect.width > window.innerWidth) {
+            left = window.innerWidth - bubbleRect.width - 8;
+        }
+
+        this.bubbleEl.style.top = `${top + window.scrollY}px`;
+        this.bubbleEl.style.left = `${left + window.scrollX}px`;
+    }
+
+    private hideBubbleMenu() {
+        if (this.bubbleEl) {
+            this.bubbleEl.remove();
+            this.bubbleEl = null;
+        }
+        this.currentSelection = null;
+        if (this.hideTimeout) {
+            clearTimeout(this.hideTimeout);
+            this.hideTimeout = null;
+        }
+    }
+
+    private async handleDictionaryLookup() {
+        if (!this.currentSelection || !this.dictionaryService) return;
+
+        const selectedText = this.currentSelection.trim();
+        this.hideBubbleMenu();
+
+        const modal = new DictionaryResultModal(this.plugin.app, this.plugin, selectedText);
+        modal.open();
+        modal.startStreaming();
+
+        try {
+            await this.dictionaryService.lookupWordStream(
+                selectedText,
+                (chunk) => modal.appendStreamChunk(chunk),
+                () => modal.completeStreaming(),
+                (error) => modal.showError(error.message)
+            );
+        } catch (error) {
+            modal.showError(error instanceof Error ? error.message : t('dictionary.lookup_failed'));
+        }
+    }
+
+    private async handleTranslation() {
+        const selectedText = this.currentSelection;
+        
+        if (!selectedText || !this.translationService) {
+            new Notice(t('selection_bubble.translation_not_configured'));
+            return;
+        }
+
+        this.hideBubbleMenu();
+
+        const modal = new TranslationResultModal(this.plugin.app, selectedText);
+        modal.open();
+        modal.startStreaming();
+
+        try {
+            await this.translationService.translateStream(
+                selectedText,
+                (chunk) => modal.appendStreamChunk(chunk),
+                () => modal.completeStreaming(),
+                (error) => modal.showError(error.message)
+            );
+        } catch (error) {
+            modal.showError(error instanceof Error ? error.message : t('selection_bubble.translation_failed'));
+        }
+    }
+
+    private async handleGrammarAnalysis() {
+        const selectedText = this.currentSelection;
+        
+        if (!selectedText || !this.grammarService) {
+            new Notice(t('selection_bubble.grammar_not_configured'));
+            return;
+        }
+
+        this.hideBubbleMenu();
+
+        const modal = new GrammarAnalysisModal(this.plugin.app, selectedText);
+        modal.open();
+        modal.startStreaming();
+
+        try {
+            await this.grammarService.analyzeGrammarStream(
+                selectedText,
+                (chunk) => modal.appendStreamChunk(chunk),
+                () => modal.completeStreaming(),
+                (error) => modal.showError(error.message)
+            );
+        } catch (error) {
+            modal.showError(error instanceof Error ? error.message : t('selection_bubble.grammar_failed'));
+        }
+    }
+
+    private handleAddToVocabulary() {
+        if (!this.currentSelection) return;
+
+        const selectedText = this.currentSelection.trim();
+        this.hideBubbleMenu();
+
+        this.plugin.addOrEditWord(selectedText, '');
+    }
+
+    updateSettings() {
+        this.initializeServices();
+    }
+
+    onunload() {
+        this.hideBubbleMenu();
+    }
+}

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -355,6 +355,42 @@ export class HiWordsSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
         });
 
+        // 文本选择气泡菜单配置
+        new Setting(containerEl)
+            .setName(t('settings.selection_bubble_menu'))
+            .setHeading();
+
+        // 启用AI取词
+        new Setting(containerEl)
+            .setName(t('settings.enable_selection_bubble'))
+            .setDesc(t('settings.enable_selection_bubble_desc'))
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.selectionBubble ?? true)
+                .onChange(async (value) => {
+                    this.plugin.settings.selectionBubble = value;
+                    await this.plugin.saveSettings();
+                }));
+        // AI 助手输出语言
+        new Setting(containerEl)
+            .setName(t('settings.ai_output_language'))
+            .setDesc(t('settings.ai_output_language_desc'))
+            .addDropdown(dropdown => dropdown
+                .addOption('Chinese (Simplified)', 'Chinese (Simplified)')
+                .addOption('English', 'English')
+                .addOption('Japanese', 'Japanese')
+                .addOption('Korean', 'Korean')
+                .addOption('French', 'French')
+                .addOption('German', 'German')
+                .addOption('Spanish', 'Spanish')
+                .addOption('Russian', 'Russian')
+                .addOption('Portuguese', 'Portuguese')
+                .addOption('Italian', 'Italian')
+                .setValue(this.plugin.settings.aiOutputLanguage || 'Chinese (Simplified)')
+                .onChange(async (value) => {
+                    this.plugin.settings.aiOutputLanguage = value;
+                    await this.plugin.saveSettings();
+                }));
+
     }
 
     /**

--- a/src/ui/translation-result-modal.ts
+++ b/src/ui/translation-result-modal.ts
@@ -1,0 +1,106 @@
+import { App, Modal, setIcon } from 'obsidian';
+import type { TranslationResult } from '../utils';
+import { t } from '../i18n';
+
+export class TranslationResultModal extends Modal {
+    private originalText: string;
+    private translatedText: string = '';
+    private isStreaming: boolean = false;
+    private translatedTextEl!: HTMLElement;
+    private copyTranslatedBtn!: HTMLElement;
+
+    constructor(app: App, originalText: string) {
+        super(app);
+        this.originalText = originalText;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass('hiwords-translation-modal');
+
+        const headerEl = contentEl.createDiv({ cls: 'hiwords-modal-header' });
+        headerEl.createEl('h2', { text: t('translation.title'), cls: 'hiwords-modal-title' });
+
+        const contentContainer = contentEl.createDiv({ cls: 'hiwords-modal-content' });
+        const originalSection = contentContainer.createDiv({ cls: 'hiwords-translation-section' });
+
+        const originalTextEl = originalSection.createDiv({ 
+            text: this.originalText, 
+            cls: 'hiwords-translation-text' 
+        });
+
+        const copyOriginalBtn = originalSection.createDiv({ cls: 'hiwords-copy-button' });
+        setIcon(copyOriginalBtn, 'copy');
+        copyOriginalBtn.setAttribute('aria-label', t('common.copy'));
+        copyOriginalBtn.addEventListener('click', () => {
+            navigator.clipboard.writeText(this.originalText);
+            copyOriginalBtn.empty();
+            setIcon(copyOriginalBtn, 'check');
+            setTimeout(() => {
+                copyOriginalBtn.empty();
+                setIcon(copyOriginalBtn, 'copy');
+            }, 2000);
+        });
+
+        const divider = contentContainer.createDiv({ cls: 'hiwords-divider' });
+        setIcon(divider, 'arrow-down');
+
+        const translatedSection = contentContainer.createDiv({ cls: 'hiwords-translation-section' });
+
+        this.translatedTextEl = translatedSection.createDiv({ 
+            text: t('translation.translating'), 
+            cls: 'hiwords-translation-text hiwords-translation-result hiwords-streaming-content' 
+        });
+
+        this.copyTranslatedBtn = translatedSection.createDiv({ cls: 'hiwords-copy-button' });
+        setIcon(this.copyTranslatedBtn, 'copy');
+        this.copyTranslatedBtn.setAttribute('aria-label', t('common.copy'));
+        this.copyTranslatedBtn.style.display = 'none';
+        this.copyTranslatedBtn.addEventListener('click', () => {
+            navigator.clipboard.writeText(this.translatedText);
+            this.copyTranslatedBtn.empty();
+            setIcon(this.copyTranslatedBtn, 'check');
+            setTimeout(() => {
+                this.copyTranslatedBtn.empty();
+                setIcon(this.copyTranslatedBtn, 'copy');
+            }, 2000);
+        });
+    }
+
+    startStreaming() {
+        this.isStreaming = true;
+        this.translatedText = '';
+        this.translatedTextEl.empty();
+        this.translatedTextEl.setText(t('translation.translating'));
+        this.copyTranslatedBtn.style.display = 'none';
+    }
+
+    appendStreamChunk(chunk: string) {
+        if (!this.isStreaming) return;
+        
+        this.translatedText += chunk;
+        this.translatedTextEl.setText(this.translatedText);
+    }
+
+    completeStreaming() {
+        this.isStreaming = false;
+        this.translatedTextEl.removeClass('hiwords-streaming-content');
+        this.translatedTextEl.addClass('hiwords-stream-complete');
+        this.copyTranslatedBtn.style.display = '';
+    }
+
+    showError(error: string) {
+        this.isStreaming = false;
+        this.translatedTextEl.empty();
+        this.translatedTextEl.createEl('p', { 
+            text: error, 
+            cls: 'hiwords-error' 
+        });
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/utils/markdown-renderer.ts
+++ b/src/utils/markdown-renderer.ts
@@ -1,0 +1,62 @@
+import { App, MarkdownRenderer, Component } from 'obsidian';
+
+export async function renderMarkdownToElement(
+    app: App,
+    markdown: string,
+    containerEl: HTMLElement,
+    sourcePath: string = ''
+): Promise<Component> {
+    const component = new Component();
+    component.load();
+
+    try {
+        await MarkdownRenderer.render(
+            app,
+            markdown,
+            containerEl,
+            sourcePath,
+            component
+        );
+    } catch (error) {
+        console.error('Failed to render markdown:', error);
+        containerEl.textContent = markdown;
+    }
+
+    return component;
+}
+
+export function renderMarkdownToHTML(markdown: string): string {
+    const lines = markdown.split('\n');
+    let html = '';
+    
+    for (const line of lines) {
+        if (line.startsWith('**') && line.endsWith('**')) {
+            const content = line.slice(2, -2);
+            html += `<h3>${escapeHtml(content)}</h3>`;
+        } else if (line.startsWith('## ')) {
+            html += `<h2>${escapeHtml(line.slice(3))}</h2>`;
+        } else if (line.startsWith('# ')) {
+            html += `<h1>${escapeHtml(line.slice(2))}</h1>`;
+        } else if (line.match(/^\d+\.\s/)) {
+            html += `<p>${escapeHtml(line)}</p>`;
+        } else if (line.trim().startsWith('-')) {
+            const content = line.trim().slice(1).trim();
+            if (content.startsWith('*') && content.includes('*', 1)) {
+                const parts = content.split('*');
+                html += `<p class="hiwords-example">• <em>${escapeHtml(parts[1])}</em></p>`;
+            } else {
+                html += `<p class="hiwords-detail">• ${escapeHtml(content)}</p>`;
+            }
+        } else if (line.trim()) {
+            html += `<p>${escapeHtml(line)}</p>`;
+        }
+    }
+    
+    return html;
+}
+
+function escapeHtml(text: string): string {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -58,6 +58,10 @@ export interface HiWordsSettings {
     highlightPaths?: string; // 文件路径列表（逗号分隔）
     // 文件节点解析模式
     fileNodeParseMode?: 'filename' | 'content' | 'filename-with-alias'; // 文件节点解析模式
+    // 文本选择气泡菜单配置
+    selectionBubble?: boolean;
+    // AI 助手输出语言（查词和语法分析共用）
+    aiOutputLanguage?: string;
 }
 
 // 词汇匹配信息

--- a/styles.css
+++ b/styles.css
@@ -1094,3 +1094,405 @@
         transform: rotate(360deg);
     }
 }
+
+/* Selection Bubble Menu Styles */
+.hiwords-selection-bubble {
+    position: absolute;
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+    z-index: 1000;
+    display: flex;
+    gap: 4px;
+    animation: hiwords-bubble-fade-in 0.2s ease;
+}
+
+@keyframes hiwords-bubble-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.hiwords-bubble-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 6px 10px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background 0.2s;
+    box-shadow: none!important;
+    color: var(--text-muted);
+}
+
+.hiwords-bubble-button:hover {
+    background: var(--background-modifier-hover);
+    color: var(--text-normal);
+}
+
+.hiwords-bubble-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hiwords-bubble-icon svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* Dictionary Result Modal Styles */
+.hiwords-dictionary-modal .modal-content {
+    max-width: 600px;
+}
+
+.hiwords-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.hiwords-modal-title-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+}
+
+.hiwords-modal-title {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.hiwords-modal-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.hiwords-play-button,
+.hiwords-add-button {
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    transition: all 0.2s;
+}
+
+.hiwords-play-button:hover,
+.hiwords-add-button:hover {
+    background: var(--background-modifier-hover);
+    color: var(--interactive-accent);
+}
+
+.hiwords-play-button svg,
+.hiwords-add-button svg {
+    width: 20px;
+    height: 20px;
+}
+
+.hiwords-add-button.hiwords-word-saved {
+    color: #fbbf24;
+}
+
+.hiwords-add-button.hiwords-word-saved svg {
+    fill: #fbbf24;
+}
+
+.hiwords-book-select-container {
+    margin: 0 4px;
+}
+
+.hiwords-book-select {
+    font-size: 13px;
+    padding: 4px 8px;
+}
+.hiwords-phonetic {
+    font-size: 16px;
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.hiwords-modal-actions-button {
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    transition: all 0.2s;
+}
+
+.hiwords-modal-actions-button:hover {
+    background: var(--background-modifier-hover);
+    color: var(--interactive-accent);
+}
+
+.hiwords-modal-actions-button svg {
+    width: 20px;
+    height: 20px;
+}
+
+.hiwords-modal-content {
+    max-height: 60vh;
+    overflow-y: auto;
+    padding: 0 4px;
+}
+
+.hiwords-meaning {
+    margin-bottom: 20px;
+}
+
+.hiwords-part-of-speech {
+    color: var(--interactive-accent);
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.hiwords-definitions {
+    padding-left: 8px;
+}
+
+.hiwords-definition-item {
+    margin-bottom: 12px;
+}
+
+.hiwords-definition-text {
+    font-size: 14px;
+    color: var(--text-normal);
+    line-height: 1.6;
+    margin-bottom: 6px;
+}
+
+.hiwords-example {
+    font-size: 13px;
+    color: var(--text-muted);
+    font-style: italic;
+    padding-left: 16px;
+    margin-top: 4px;
+}
+
+.hiwords-related-words {
+    font-size: 12px;
+    color: var(--text-muted);
+    padding-left: 16px;
+    margin-top: 4px;
+}
+
+.hiwords-label {
+    font-weight: 600;
+    color: var(--text-normal);
+}
+
+.hiwords-source {
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px solid var(--background-modifier-border);
+    text-align: right;
+}
+
+.hiwords-no-result {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 20px;
+}
+
+.hiwords-modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px solid var(--background-modifier-border);
+}
+
+/* Translation Result Modal Styles */
+.hiwords-translation-modal .modal-content {
+    max-width: 600px;
+}
+
+.hiwords-translation-section {
+    position: relative;
+    background: var(--background-secondary);
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 16px;
+}
+
+.hiwords-translation-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.hiwords-language-tag {
+    font-size: 11px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    font-weight: 600;
+}
+
+.hiwords-translation-text {
+    font-size: 15px;
+    color: var(--text-normal);
+    line-height: 1.7;
+    word-wrap: break-word;
+}
+
+.hiwords-translation-result {
+    font-weight: 500;
+}
+
+.hiwords-copy-button {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    cursor: pointer;
+    padding: 6px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    transition: all 0.2s;
+}
+
+.hiwords-copy-button:hover {
+    background: var(--background-modifier-hover);
+    color: var(--interactive-accent);
+}
+
+.hiwords-copy-button svg {
+    width: 16px;
+    height: 16px;
+}
+
+.hiwords-divider {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    margin: 8px 0;
+}
+
+.hiwords-divider svg {
+    width: 20px;
+    height: 20px;
+}
+
+/* Grammar Analysis Modal Styles */
+.hiwords-grammar-modal .modal-content {
+    max-width: 700px;
+}
+
+.hiwords-grammar-section {
+    margin-bottom: 20px;
+}
+
+.hiwords-section-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-normal);
+    margin-bottom: 12px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.hiwords-grammar-original {
+    background: var(--background-secondary);
+    border-left: 4px solid var(--interactive-accent);
+    border-radius: 4px;
+    padding: 12px;
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--text-normal);
+    font-style: italic;
+}
+
+.hiwords-grammar-analysis {
+    font-size: 14px;
+    line-height: 1.8;
+    color: var(--text-normal);
+}
+
+.hiwords-grammar-analysis h1,
+.hiwords-grammar-analysis h2,
+.hiwords-grammar-analysis h3 {
+    margin-top: 16px;
+    margin-bottom: 8px;
+}
+
+.hiwords-grammar-analysis p {
+    margin-bottom: 12px;
+}
+
+.hiwords-grammar-analysis ul,
+.hiwords-grammar-analysis ol {
+    margin: 8px 0;
+    padding-left: 24px;
+}
+
+.hiwords-grammar-analysis li {
+    margin-bottom: 6px;
+}
+
+.hiwords-grammar-analysis code {
+    background: var(--background-secondary);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: var(--font-monospace);
+    font-size: 13px;
+}
+
+.hiwords-grammar-analysis pre {
+    background: var(--background-secondary);
+    border-radius: 6px;
+    padding: 12px;
+    overflow-x: auto;
+    margin: 12px 0;
+}
+
+.hiwords-grammar-analysis blockquote {
+    border-left: 3px solid var(--interactive-accent);
+    padding-left: 16px;
+    margin: 12px 0;
+    color: var(--text-muted);
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .hiwords-selection-bubble {
+        padding: 1px;
+        gap: 2px;
+    }
+    
+    .hiwords-bubble-button {
+        padding: 6px 8px;
+    }
+    
+    .hiwords-modal-content {
+        max-height: 50vh;
+    }
+    
+    .hiwords-modal-title {
+        font-size: 20px;
+    }
+}


### PR DESCRIPTION
在使用过程中会遇到查词和翻译频繁切换的情况，故想增加一个词典取词的功能，提升学习体验。由于没有找到免费好用的词典接口，所以用大模型实现。

## 增加快捷工具条
选择文本或者单词，显示工具栏菜单，4个按钮分别是查词、翻译、语法分析、添加到单词本。避免查词句来回切换，增加“沉浸式”体验。
<img width="1460" height="438" alt="image" src="https://github.com/user-attachments/assets/97e59ab7-b0c1-408e-9819-68d01585f248" />
## 查词功能
在查词结果页面，增加一键收藏到单词本的快捷操作
<img width="1510" height="906" alt="image" src="https://github.com/user-attachments/assets/59d7534e-5b4c-4a1c-9707-902a19a9ea24" />

## 支持选择句子进行翻译
<img width="1384" height="674" alt="image" src="https://github.com/user-attachments/assets/c246f3a7-6a0d-4c9e-b817-44c22a976ea8" />

## 提供语句分析快捷菜单

<img width="1560" height="1262" alt="image" src="https://github.com/user-attachments/assets/6da6e5e9-9a60-4d9f-87f7-a392b1cd391f" />

## 添加到单词本
直接调起原有的单词添加界面。

## 取词菜单开关配置。所有快捷功能均基于大模型的prompt实现。
<img width="1636" height="490" alt="image" src="https://github.com/user-attachments/assets/51151975-1eb5-4af4-8cfd-a6d6b974fb10" />


